### PR TITLE
Add admin flag to users

### DIFF
--- a/database/new.sql
+++ b/database/new.sql
@@ -41,7 +41,7 @@ CREATE TABLE IF NOT EXISTS "Info" (
 
 -- TODO: Update
 INSERT INTO "Info" ("name", "value") VALUES("MAJOR", "1");
-INSERT INTO "Info" ("name", "value") VALUES("MINOR", "5");
+INSERT INTO "Info" ("name", "value") VALUES("MINOR", "6");
 
 -- FuncGroup definition
 
@@ -346,13 +346,16 @@ CREATE TABLE IF NOT EXISTS "AMSUser" (
     "amsuser_last_login"                TEXT,
     "amsuser_unsuccess_login_num"       INTEGER DEFAULT 0,
     "amsuser_active"                    INTEGER DEFAULT 0,
+    "amsuser_admin"                     INTEGER DEFAULT 0,
     PRIMARY KEY("amsuser_id")
 );
 
-INSERT INTO "AMSUser" ("amsuser_name", "amsuser_username", "amsuser_password", "amsuser_active")
+INSERT INTO "AMSUser"
+    ("amsuser_name", "amsuser_username", "amsuser_password", "amsuser_active", "amsuser_admin")
 VALUES
     ("administrator", "administrator",
-     "$argon2id$v=19$m=8192,t=100,p=1$w93g/9FGO2nAajwoi02FHw$tHjzDkGoscBHLJOGJoqh699KXvWf+JqmARrR2L4yzxk", 1);
+     "$argon2id$v=19$m=8192,t=100,p=1$w93g/9FGO2nAajwoi02FHw$tHjzDkGoscBHLJOGJoqh699KXvWf+JqmARrR2L4yzxk",
+     1, 1);
 
 -- Group for Access Management System
 

--- a/database/sql_1_6.sql
+++ b/database/sql_1_6.sql
@@ -1,6 +1,6 @@
 -- AMSUser: Every user for an account can be an admin.
 
-ALTER TABLE "AMSUser" ADD COLUMN "admin" INTEGER default 0;
+ALTER TABLE "AMSUser" ADD COLUMN "amsuser_admin" INTEGER default 0;
 
 -- Update version of database
 

--- a/database/sql_1_6.sql
+++ b/database/sql_1_6.sql
@@ -1,0 +1,8 @@
+-- AMSUser: Every user for an account can be an admin.
+
+ALTER TABLE "AMSUser" ADD COLUMN "admin" INTEGER default 0;
+
+-- Update version of database
+
+UPDATE "Info" SET "value" = "1" WHERE "name" = "MAJOR";
+UPDATE "Info" SET "value" = "6" WHERE "name" = "MINOR";

--- a/src/ams/model/qmamsusermodel.cpp
+++ b/src/ams/model/qmamsusermodel.cpp
@@ -1,22 +1,19 @@
 // qmamsusermodel.cpp is part of QualificationMatrix
 //
-// QualificationMatrix is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// QualificationMatrix is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
 //
-// QualificationMatrix is distributed in the hope that it will be useful, but
-// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-// more details.
+// QualificationMatrix is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+// the GNU General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License along
-// with QualificationMatrix. If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along with QualificationMatrix.
+// If not, see <http://www.gnu.org/licenses/>.
 
 #include "qmamsusermodel.h"
 
 #include <QColor>
-#include <QDebug>
 
 QMAMSUserModel::QMAMSUserModel(QObject *parent, const QSqlDatabase &db)
     : QMSqlTableModel(parent, db)
@@ -40,6 +37,7 @@ void QMAMSUserModel::initModel()
     setHeaderData(4, Qt::Horizontal, tr("Letzter Login"));
     setHeaderData(5, Qt::Horizontal, tr("Loginversuche"));
     setHeaderData(6, Qt::Horizontal, tr("Aktiv"));
+    setHeaderData(7, Qt::Horizontal, tr("Admin"));
 }
 
 QVariant QMAMSUserModel::data(const QModelIndex &index, int role) const

--- a/src/ams/model/qmamsusermodel.h
+++ b/src/ams/model/qmamsusermodel.h
@@ -1,17 +1,15 @@
 // qmamsusermodel.h is part of QualificationMatrix
 //
-// QualificationMatrix is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// QualificationMatrix is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
 //
-// QualificationMatrix is distributed in the hope that it will be useful, but
-// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-// more details.
+// QualificationMatrix is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+// the GNU General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License along
-// with QualificationMatrix. If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along with QualificationMatrix.
+// If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef QMAMSUSERMODEL_H
 #define QMAMSUSERMODEL_H

--- a/src/ams/qmamsmanager.cpp
+++ b/src/ams/qmamsmanager.cpp
@@ -1,12 +1,12 @@
 // qmamsmanager.cpp is part of QualificationMatrix
 //
-// QualificationMatrix is free software: you can redistribute it and/or modify it under the terms of the GNU General
-// Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
-// any later version.
+// QualificationMatrix is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
 //
-// QualificationMatrix is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
-// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-// more details.
+// QualificationMatrix is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+// the GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License along with QualificationMatrix.
 // If not, see <http://www.gnu.org/licenses/>.
@@ -28,8 +28,6 @@
 
 #include <botan/argon2.h>
 #include <botan/system_rng.h>
-
-#include <QDebug>
 
 QMAMSManager *QMAMSManager::instance = nullptr;
 
@@ -73,6 +71,9 @@ bool QMAMSManager::checkDatabase()
 
 bool QMAMSManager::checkForAdministrator(QSqlDatabase &database)
 {
+    // TODO: The administrator can be identified by the user name or by having the admin flag in
+    // the user list. For now, only the username "administrator" is an admin.
+
     QMAMSUserModel amsUserModel(this, database);
     amsUserModel.select();
 

--- a/src/ams/qmamsmanager.h
+++ b/src/ams/qmamsmanager.h
@@ -1,12 +1,12 @@
 // qmamsmanager.h is part of QualificationMatrix
 //
-// QualificationMatrix is free software: you can redistribute it and/or modify it under the terms of the GNU General
-// Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
-// any later version.
+// QualificationMatrix is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
 //
-// QualificationMatrix is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
-// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-// more details.
+// QualificationMatrix is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+// the GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License along with QualificationMatrix.
 // If not, see <http://www.gnu.org/licenses/>.

--- a/src/ams/qmamsmanager.h
+++ b/src/ams/qmamsmanager.h
@@ -83,6 +83,7 @@ struct QMAMSUserInformation
 {
     bool found = false;
     bool active = false;
+    bool admin = false;
     int failedLoginCount = 0;
 
     // The database id representing the primary key.
@@ -149,6 +150,12 @@ public:
     /// \param mode The access mode to test for.
     /// \return False if logged in user does not have the permission, else false.
     bool checkPermission(AccessMode mode);
+
+    /// Check whether the logged in user has administrator permissions or not. The admin
+    /// permission is kind of special, cause it euqals to the user "administrator" or to a user
+    /// having the admin flag set to true.
+    /// \return True if a user is logged in and has admin permissions.
+    bool checkAdminPermission();
 
     /// Get full name of the currently logged in user.
     /// \return The full name of the current login user, else empty.

--- a/src/ams/qmamsusersettingswidget.cpp
+++ b/src/ams/qmamsusersettingswidget.cpp
@@ -1,15 +1,15 @@
 // qmamssettingswidget.cpp is part of QualificationMatrix
 //
-// QualificationMatrix is free software: you can redistribute it and/or modify it under the terms of the GNU General
-// Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
-// any later version.
+// QualificationMatrix is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
 //
-// QualificationMatrix is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the
-// implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-// more details.
+// QualificationMatrix is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+// the GNU General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License along with QualificationMatrix. If not, see
-// <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along with QualificationMatrix.
+// If not, see <http://www.gnu.org/licenses/>.
 
 #include "qmamsusersettingswidget.h"
 #include "ui_qmamsusersettingswidget.h"
@@ -25,8 +25,6 @@
 #include <QMessageBox>
 #include <QSortFilterProxyModel>
 #include <QInputDialog>
-
-#include <QDebug>
 
 QMAMSUserSettingsWidget::QMAMSUserSettingsWidget(QWidget *parent)
     : QMSettingsWidget(parent, true)

--- a/src/ams/qmamsusersettingswidget.cpp
+++ b/src/ams/qmamsusersettingswidget.cpp
@@ -336,17 +336,46 @@ bool QMAMSUserSettingsWidget::userGroupProxyContainsGroup(const QString &group)
     return false;
 }
 
-void QMAMSUserSettingsWidget::userSelectionChanged(const QModelIndex &selected, const QModelIndex &deselected)
+void QMAMSUserSettingsWidget::userSelectionChanged(
+        const QModelIndex &selected, const QModelIndex &deselected)
 {
-    ui->lvGroup->reset();
-    ui->pbAddGroup->setEnabled(false);
-    ui->pbRemoveGroup->setEnabled(false);
-
     if (!selected.isValid())
     {
         deactivateUserGroupList();
         return;
     }
+
+    // update ui buttons for changing user settings
+    auto activeFieldIndex = amsUserModel->fieldIndex("amsuser_active");
+    auto activeModelIndex = amsUserModel->index(selected.row(), activeFieldIndex);
+    auto selActive = amsUserModel->data(activeModelIndex).toBool();
+
+    if (selActive)
+    {
+        ui->pbChangeActiveState->setText(tr("Deaktivieren"));
+    }
+    else
+    {
+        ui->pbChangeActiveState->setText(tr("Aktivieren"));
+    }
+
+    auto adminFieldIndex = amsUserModel->fieldIndex("amsuser_admin");
+    auto adminModelIndex = amsUserModel->index(selected.row(), adminFieldIndex);
+    auto selAdmin = amsUserModel->data(adminModelIndex).toBool();
+
+    if (selAdmin)
+    {
+        ui->pbChangeAdminState->setText(tr("Admin-Flag deakt."));
+    }
+    else
+    {
+        ui->pbChangeAdminState->setText(tr("Admin-Flag akt."));
+    }
+
+    // update ui group parts
+    ui->lvGroup->reset();
+    ui->pbAddGroup->setEnabled(false);
+    ui->pbRemoveGroup->setEnabled(false);
 
     auto selModelIndex = amsUserModel->index(selected.row(), 2);
     auto selData = amsUserModel->data(selModelIndex).toString();
@@ -396,11 +425,11 @@ void QMAMSUserSettingsWidget::changeAdminState()
 
     if (!selAdmin)
     {
-        ui->pbChangeAdminState->setText(tr("Admin-Flag deaktivieren"));
+        ui->pbChangeAdminState->setText(tr("Admin-Flag deakt."));
     }
     else
     {
-        ui->pbChangeAdminState->setText(tr("Admin-Flag aktivieren"));
+        ui->pbChangeAdminState->setText(tr("Admin-Flag akt."));
     }
 
     emitSettingsChanged();
@@ -470,19 +499,6 @@ void QMAMSUserSettingsWidget::activateUserGroupList(int selRow)
     ui->pbChangeName->setEnabled(true);
     ui->pbChangeUsername->setEnabled(true);
     ui->pbChangeActiveState->setEnabled(true);
-
-    auto activeFieldIndex = amsUserModel->fieldIndex("amsuser_active");
-    auto activeModelIndex = amsUserModel->index(selRow, activeFieldIndex);
-    auto selActive = amsUserModel->data(activeModelIndex).toBool();
-
-    if (selActive)
-    {
-        ui->pbChangeActiveState->setText(tr("Deaktivieren"));
-    }
-    else
-    {
-        ui->pbChangeActiveState->setText(tr("Aktivieren"));
-    }
 
     auto selModelIndex = amsUserModel->index(selRow, 2);
     auto selData = amsUserModel->data(selModelIndex).toString();

--- a/src/ams/qmamsusersettingswidget.cpp
+++ b/src/ams/qmamsusersettingswidget.cpp
@@ -38,6 +38,7 @@ QMAMSUserSettingsWidget::QMAMSUserSettingsWidget(QWidget *parent)
     booleanDelegate->setEditable(true);
     ui->tvUser->setEditTriggers(QAbstractItemView::NoEditTriggers);
     ui->tvUser->setItemDelegateForColumn(6, booleanDelegate);
+    ui->tvUser->setItemDelegateForColumn(7, booleanDelegate);
 }
 
 QMAMSUserSettingsWidget::~QMAMSUserSettingsWidget()
@@ -357,6 +358,52 @@ void QMAMSUserSettingsWidget::userSelectionChanged(const QModelIndex &selected, 
     }
 
     activateUserGroupList(selected.row());
+}
+
+void QMAMSUserSettingsWidget::changeAdminState()
+{
+    auto selRows = ui->tvUser->selectionModel()->selectedRows();
+    if (selRows.count() != 1)
+    {
+        qWarning() << "wrong number of selected rows";
+    }
+
+    auto selRow = selRows.first().row();
+
+    auto usernameFieldIndex = amsUserModel->fieldIndex("amsuser_username");
+    auto usernameModelIndex = amsUserModel->index(selRow, usernameFieldIndex);
+    auto selUsername = amsUserModel->data(usernameModelIndex).toString();
+
+    // Don't change if selected user is administrator.
+    if (selUsername.compare("administrator") == 0)
+    {
+        QMessageBox::information(this, tr("Admin-Status ändern"),
+                tr("Der Admin-Status von 'administrator' kann nicht geändert werden."));
+        return;
+    }
+
+    auto adminFieldIndex = amsUserModel->fieldIndex("amsuser_admin");
+    auto adminModelIndex = amsUserModel->index(selRow, adminFieldIndex);
+    auto selAdmin = amsUserModel->data(adminModelIndex).toBool();
+
+    // Change the admin state.
+    if (!amsUserModel->setData(adminModelIndex, !selAdmin))
+    {
+        QMessageBox::information(this, tr("Admin-Status ändern"),
+                tr("Der Admin-Status konnte nicht geändert werden."));
+        return;
+    }
+
+    if (!selAdmin)
+    {
+        ui->pbChangeAdminState->setText(tr("Admin-Flag deaktivieren"));
+    }
+    else
+    {
+        ui->pbChangeAdminState->setText(tr("Admin-Flag aktivieren"));
+    }
+
+    emitSettingsChanged();
 }
 
 void QMAMSUserSettingsWidget::changeActiveState()

--- a/src/ams/qmamsusersettingswidget.h
+++ b/src/ams/qmamsusersettingswidget.h
@@ -1,17 +1,15 @@
 // qmamssettingswidget.h is part of QualificationMatrix
 //
-// QualificationMatrix is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by the
-// Free Software Foundation, either version 3 of the License, or (at your
-// option) any later version.
+// QualificationMatrix is free software: you can redistribute it and/or modify it under the terms
+// of the GNU General Public License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
 //
-// QualificationMatrix is distributed in the hope that it will be useful, but
-// WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
-// or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-// more details.
+// QualificationMatrix is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+// the GNU General Public License for more details.
 //
-// You should have received a copy of the GNU General Public License along
-// with QualificationMatrix. If not, see <http://www.gnu.org/licenses/>.
+// You should have received a copy of the GNU General Public License along with QualificationMatrix.
+// If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef QMAMSUSERSETTINGSWIDGET_H
 #define QMAMSUSERSETTINGSWIDGET_H

--- a/src/ams/qmamsusersettingswidget.h
+++ b/src/ams/qmamsusersettingswidget.h
@@ -97,6 +97,9 @@ public slots:
     /// Changes the user from activated to deactivated and vise versa.
     void changeActiveState();
 
+    /// Changes the user admin state, which can be activated or deactivated.
+    void changeAdminState();
+
 private:
     /// Get the username from the given primary id.
     /// \param primaryId The primary key id in the table AMSUser.

--- a/src/config.h
+++ b/src/config.h
@@ -22,7 +22,7 @@
 // Define the minimum version a db must have, otherwise the software won't work with it - 0, 0 means no version
 // table or entry is available, cause the first version doesn't include this information.
 #define DB_MIN_MAJOR 1
-#define DB_MIN_MINOR 5
+#define DB_MIN_MINOR 6
 
 // BackupManager system
 #define BACKUP_META_FILE_VERSION 1

--- a/src/settings/qmsettingsdialog.cpp
+++ b/src/settings/qmsettingsdialog.cpp
@@ -90,7 +90,7 @@ void QMSettingsDialog::initStackWidgets()
     }
 
     // Don't show permission configuration if administrator ist not logged in.
-    if (amsManager->getLoginUserName().compare("administrator") == 0)
+    if (amsManager->checkAdminPermission())
     {
         appendConnectSettingsWidget(new QMAMSUserSettingsWidget(this));
         appendConnectSettingsWidget(new QMAMSGroupSettingsWidget(this));
@@ -155,7 +155,7 @@ void QMSettingsDialog::initTreeWidgets()
 
 
     // Don't show permission configuration if administrator ist not logged in.
-    if (amsManager->getLoginUserName().compare("administrator") == 0)
+    if (amsManager->checkAdminPermission())
     {
         auto twiAMS = new QTreeWidgetItem(ui->twSettingGroups);
         twiAMS->setText(0, tr("Rechtverwaltung"));
@@ -431,13 +431,8 @@ void QMSettingsDialog::changeSettingsGroup(QTreeWidgetItem *item, const int)
         }
 
         auto am = QMAMSManager::getInstance();
-        if (settingsWidget->adminAccessNeeded() &&
-            am->getLoginUserName().compare("administrator") != 0)
+        if (settingsWidget->adminAccessNeeded() && am->checkAdminPermission())
         {
-            QMAMSLoginDialog loginDialog(this);
-            loginDialog.setUsername("administrator");
-            loginDialog.exec();
-
             settingsWidget->show();
         }
     }

--- a/src/settings/qmsettingswidget.cpp
+++ b/src/settings/qmsettingswidget.cpp
@@ -31,13 +31,11 @@ void QMSettingsWidget::showEvent(QShowEvent *event)
 {
     if (admin)
     {
-        // If the administrator account is needed to get access to the widget: Test if the administrator is logged in,
-        // else set the widget to invisible.
-
+        // Test if administrator is logged in to get access to the admin interface.
         auto am = QMAMSManager::getInstance();
-        if (am->getLoginUserName().compare("administrator") != 0)
+        if (!am->checkAdminPermission())
         {
-            qDebug() << "Try to open admin widget without being logged in";
+            qDebug() << "Try to open admin widget without being logged in as an administrator";
             setVisible(false);
             return;
         }

--- a/ui/qmamsusersettingswidget.ui
+++ b/ui/qmamsusersettingswidget.ui
@@ -157,6 +157,13 @@
            </widget>
           </item>
           <item>
+           <widget class="QPushButton" name="pbChangeAdminState">
+            <property name="text">
+             <string>Admin-Flag aktivieren</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -459,6 +466,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>pbChangeAdminState</sender>
+   <signal>clicked()</signal>
+   <receiver>QMAMSUserSettingsWidget</receiver>
+   <slot>changeAdminState()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>711</x>
+     <y>287</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>583</x>
+     <y>380</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>addUser()</slot>
@@ -472,5 +495,6 @@
   <slot>changeName()</slot>
   <slot>resetLoginNum()</slot>
   <slot>changeActiveState()</slot>
+  <slot>changeAdminState()</slot>
  </slots>
 </ui>

--- a/ui/qmamsusersettingswidget.ui
+++ b/ui/qmamsusersettingswidget.ui
@@ -159,7 +159,7 @@
           <item>
            <widget class="QPushButton" name="pbChangeAdminState">
             <property name="text">
-             <string>Admin-Flag aktivieren</string>
+             <string>Admin-Flag akt.</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Given a new admin flag, special ams user have now access to administrator restricted parts of the ui. Be aware, that this is still not a security safe feature. It just prevents normal accounts to do unwanted actions by accident.