### PR TITLE
Extend usernames for accounts

### DIFF
--- a/src/ams/qmamsmanager.cpp
+++ b/src/ams/qmamsmanager.cpp
@@ -119,7 +119,7 @@ bool QMAMSManager::setFailedLoginCount(QString &name, int count)
         auto usernameModelIndex = amsUserModel.index(i, usernameFieldIndex);
         auto dbUsername = amsUserModel.data(usernameModelIndex).toString();
 
-        if (dbUsername == name)
+        if (dbUsername.toUpper().compare(name.toUpper()))
         {
             auto failedLoginModelIndex = amsUserModel.index(i,
                     failedLoginIndex);
@@ -164,7 +164,7 @@ bool QMAMSManager::setLastLoginDateTime(QString &name)
         auto usernameModelIndex = amsUserModel.index(i, usernameFieldIndex);
         auto dbUsername = amsUserModel.data(usernameModelIndex).toString();
 
-        if (dbUsername.compare(name) == 0)
+        if (dbUsername.toUpper().compare(name.toUpper()) == 0)
         {
             auto currDateTime = QDateTime::currentDateTime();
             auto strCurrDateTime = currDateTime.toString(Qt::ISODate);
@@ -333,6 +333,7 @@ bool QMAMSManager::createAdminInDatabase()
     record.append(QSqlField("amsuser_last_login"));
     record.append(QSqlField("amsuser_unsuccess_login_num"));
     record.append(QSqlField("amsuser_active"));
+    record.append(QSqlField("amsuser_admin"));
 
     record.setValue("amsuser_name", "administrator");
     record.setValue("amsuser_username", "administrator");
@@ -340,6 +341,7 @@ bool QMAMSManager::createAdminInDatabase()
     record.setValue("amsuser_last_login", "");
     record.setValue("amsuser_unsuccess_login_num", 0);
     record.setValue("amsuser_active", 1);
+    record.setValue("amsuser_admin", 1);
 
     if (!amsUserModel.insertRecord(-1, record) || !amsUserModel.submitAll())
     {
@@ -675,7 +677,7 @@ QList<QString> QMAMSManager::getUserGroupsFromDatabase(const QString &username)
     {
         auto usernameModelIndex = amsUserGroupModel.index(i, usernameFieldIndex);
         auto dbUsername = amsUserGroupModel.data(usernameModelIndex).toString();
-        if (dbUsername.compare(username) == 0)
+        if (dbUsername.toUpper().compare(username.toUpper()) == 0)
         {
             // Get the group name.
             auto groupnameModelIndex = amsUserGroupModel.index(i, groupnameFieldIndex);
@@ -714,7 +716,7 @@ QMAMSUserInformation QMAMSManager::getUserFromDatabase(const QString &username)
         auto usernameModelIndex = amsUserModel.index(i, usernameFieldIndex);
         auto dbUsername = amsUserModel.data(usernameModelIndex).toString();
 
-        if (dbUsername == username)
+        if (dbUsername.toUpper().compare(username.toUpper()) == 0)
         {
             auto idFieldIndex = amsUserModel.fieldIndex("amsuser_id");
             auto idModelIndex = amsUserModel.index(i, idFieldIndex);

--- a/src/ams/qmamsmanager.h
+++ b/src/ams/qmamsmanager.h
@@ -74,7 +74,8 @@ enum class LoginState
 /// The struct holds information about general access permissions for a user.
 struct QMAMSUserGeneralAccessPermissions
 {
-    // A list with access modes from the database. The codes must be available as an enum from AccessMode.
+    // A list with access modes from the database. The codes must be available as an enum from
+    // AccessMode.
     QList<int> accessModes;
 };
 
@@ -97,8 +98,8 @@ struct QMAMSUserInformation
 
     QMAMSUserGeneralAccessPermissions generalPermissions;
 
-    // Variable holds a list of primary keys of the users that are visible. All other users should never be visible
-    // to the currently logged in user.
+    // Variable holds a list of primary keys of the users that are visible. All other users should
+    // never be visible to the currently logged in user.
     QList<int> allowedUsersPrimaryKeys;
 };
 

--- a/src/ams/qmamsusersettingswidget.cpp
+++ b/src/ams/qmamsusersettingswidget.cpp
@@ -676,7 +676,7 @@ bool QMAMSUserSettingsWidget::userContainsUsername(const QString &username)
         auto usernameModelIndex = amsUserModel->index(i, usernameFieldIndex);
         auto tmpUsername = amsUserModel->data(usernameModelIndex).toString();
 
-        if (tmpUsername.compare(username) == 0)
+        if (tmpUsername.toUpper().compare(username.toUpper()) == 0)
         {
             return true;
         }

--- a/src/ams/qmamsusersettingswidget.cpp
+++ b/src/ams/qmamsusersettingswidget.cpp
@@ -636,11 +636,13 @@ void QMAMSUserSettingsWidget::changeUsername()
             return;
         }
 
-        // The username should consist of letters and numbers.
+        // The username should consist letters and numbers.
         if (!newUsername.contains(QRegularExpression("^[a-zA-Z0-9]+$")) || newUsername.length() < 5)
         {
-            QMessageBox::information(this, tr("Benutzername ändern"),
-                    tr("Der Benutzername darf nur Buchstaben enthalten und muss mindestens 6 Zeichen lang sein."));
+            QMessageBox::information(
+                    this, tr("Benutzername ändern"),
+                    tr("Der Benutzername darf nur Buchstaben enthalten und muss mindestens 6 Zeichen lang sein.")
+            );
             continue;
         }
 

--- a/src/ams/qmamsusersettingswidget.cpp
+++ b/src/ams/qmamsusersettingswidget.cpp
@@ -636,8 +636,8 @@ void QMAMSUserSettingsWidget::changeUsername()
             return;
         }
 
-        // The username should only consist of letters.
-        if (!newUsername.contains(QRegularExpression("^[a-zA-Z]+$")) || newUsername.length() < 6)
+        // The username should consist of letters and numbers.
+        if (!newUsername.contains(QRegularExpression("^[a-zA-Z0-9]+$")) || newUsername.length() < 5)
         {
             QMessageBox::information(this, tr("Benutzername ändern"),
                     tr("Der Benutzername darf nur Buchstaben enthalten und muss mindestens 6 Zeichen lang sein."));


### PR DESCRIPTION
Usernames are now allowed to contain numbers and at least 5 characters are needed. The username check is now case insensitive.